### PR TITLE
Fixing a typo in the Python setup file.

### DIFF
--- a/dev_environments/python.ps1
+++ b/dev_environments/python.ps1
@@ -1,5 +1,5 @@
 # How to run this file:
-#  PS> iwr -useb https://raw.githubusercontent.com/JayBazuzi/machine-setup/main/dev-environments/python.ps1 | iex
+#  PS> iwr -useb https://raw.githubusercontent.com/JayBazuzi/machine-setup/main/dev_environments/python.ps1 | iex
 
 iwr -useb https://raw.githubusercontent.com/JayBazuzi/machine-setup/main/windows.ps1 | iex
 iwr -useb https://raw.githubusercontent.com/JayBazuzi/machine-setup/main/python-pycharm.ps1 | iex


### PR DESCRIPTION
Typo in the python setup file was causing the command to 404. Needed an underscore instead of a hyphen.